### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-random.opam
+++ b/mirage-random.opam
@@ -16,7 +16,7 @@ build: [
 ]
 
 depends: [
-  "dune" {build & >="1.1.0"}
+  "dune" {>="1.1.0"}
   "cstruct" {>= "1.9.0"}
   "ocaml" {>= "4.04.2"}
 ]


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.