### PR TITLE
use Cstruct.t directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ sudo: required
 env:
   global:
     - PACKAGE="mirage-random"
-    - PINS="mirage-random.dev:."
+    - PINS="mirage-random.2.0.0:."
     - REVDEPS=true
   matrix:
-    - OCAML_VERSION=4.04
-    - OCAML_VERSION=4.05
     - OCAML_VERSION=4.06
     - OCAML_VERSION=4.07
+    - OCAML_VERSION=4.08
+    - OCAML_VERSION=4.09
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: required
 env:
   global:
     - PACKAGE="mirage-random"
-    - PINS="mirage-random.2.0.0:."
     - REVDEPS=true
   matrix:
     - OCAML_VERSION=4.06

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
-### v2.0.0
+### v2.0.0 (2019-10-21)
 
-* Specialise buffer to Cstruct.t directly in Mirage_random.S
-* Deprecate Mirage_random.C
+* Specialise buffer to Cstruct.t directly in Mirage_random.S (#12 @hannesm)
+* Deprecate Mirage_random.C (#12 @hannesm)
+* Raise lower bound of OCaml to 4.06.0 (#12 @hannesm)
 
 ### v1.2.0 (2018-11-11)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### v2.0.0
+
+* Specialise buffer to Cstruct.t directly in Mirage_random.S
+* Deprecate Mirage_random.C
+
 ### v1.2.0 (2018-11-11)
 
 * Move Stdlibrandom to a separate package, mirage-random-stdlib

--- a/mirage-random.opam
+++ b/mirage-random.opam
@@ -17,12 +17,11 @@ build: [
 
 depends: [
   "dune" {>="1.1.0"}
-  "cstruct" {>= "1.9.0"}
-  "ocaml" {>= "4.04.2"}
+  "cstruct" {>= "4.0.0"}
+  "ocaml" {>= "4.06.0"}
 ]
 
 synopsis: "Random-related devices for MirageOS"
 description: """
-mirage-random defines `Mirage_random.S` and `Mirage_random.C` the signature for
-random-related devices for MirageOS.
+mirage-random defines `Mirage_random.S` the signature for random-related devices for MirageOS.
 """

--- a/src/mirage_random.ml
+++ b/src/mirage_random.ml
@@ -25,16 +25,13 @@
 (** {1 Operations to generate random numbers} *)
 module type S = sig
 
-  type buffer
-  (** The type for memory buffer. *)
-
   type g
   (** The state of the generator. *)
 
-  val generate: ?g:g -> int -> buffer
+  val generate: ?g:g -> int -> Cstruct.t
   (** [generate ~g n] generates a random buffer of length [n] using [g]. *)
 
 end
 
-(** Operations to generated random numbers using [Cstruct] buffers. *)
-module type C = S with type buffer = Cstruct.t
+module type C = S
+[@@ocaml.deprecated "This module alias to Mirage_random.S will be removed from MirageOS 4.0, use Mirage_random.S directly."]


### PR DESCRIPTION
as discussed in mirage/mirage#1004
- Mirage_random.C is kept with a deprecation warning